### PR TITLE
Package semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,8 @@ It parses out the flags it understands, passing the rest through to
 
 ## TODOs
 
-- [ ] (Soon) Replace square-specific handling of `go_package` with
-      recently updated upstream logic. (We have a modified plugin that
-      splits on dots in `package` and `go_package` to set the full
-      output path. I accidentally left this logic in, and can't remove
-      it until we add new-style `go_package` declarations to all our
-      protos.)
-
+- [x] (Soon) Replace square-specific handling of `go_package` with
+      recently updated upstream logic.
 - [ ] In the initial call to `protoc` for generating
       FileDescriptorProtos, pass `.proto` files to `protoc` in batches
       instead of all at once.

--- a/cmd/cyclecheck/cyclecheck.go
+++ b/cmd/cyclecheck/cyclecheck.go
@@ -30,6 +30,7 @@ var customFlags = map[string]bool{
 	"print_structure":      false,
 	"protoc_command":       true,
 	"only_specified_files": false,
+	"square_packages":      false,
 }
 
 func usageAndExit(format string, args ...interface{}) {
@@ -62,13 +63,18 @@ func main() {
 	if err != nil {
 		usageAndExit("Error: %v\n", err)
 	}
+	squarePackages, err := flags.Bool("square_packages", false)
+	if err != nil {
+		usageAndExit("Error: %v\n", err)
+	}
 
 	w := &wrapper.Wrapper{
-		ProtocCommand: flags.String("protoc_command", "protoc"),
-		ProtocFlags:   protocFlags,
-		ProtoFiles:    protos,
-		ImportDirs:    importDirs,
-		NoExpand:      noExpand,
+		ProtocCommand:          flags.String("protoc_command", "protoc"),
+		ProtocFlags:            protocFlags,
+		ProtoFiles:             protos,
+		ImportDirs:             importDirs,
+		NoExpand:               noExpand,
+		SquarePackageSemantics: squarePackages,
 	}
 	err = w.Init()
 	if err != nil {

--- a/cmd/protowrap/protowrap.go
+++ b/cmd/protowrap/protowrap.go
@@ -32,6 +32,7 @@ var customFlags = map[string]bool{
 	"protoc_command":       true,
 	"only_specified_files": false,
 	"print_only":           false,
+	"square_packages":      false,
 }
 
 func usageAndExit(format string, args ...interface{}) {
@@ -76,15 +77,20 @@ func main() {
 	if err != nil {
 		usageAndExit("Error: %v\n", err)
 	}
+	squarePackages, err := flags.Bool("square_packages", false)
+	if err != nil {
+		usageAndExit("Error: %v\n", err)
+	}
 
 	w := &wrapper.Wrapper{
-		ProtocCommand: flags.String("protoc_command", "protoc"),
-		ProtocFlags:   protocFlags,
-		ProtoFiles:    protos,
-		ImportDirs:    importDirs,
-		NoExpand:      noExpand,
-		Parallelism:   parallelism,
-		PrintOnly:     printOnly,
+		ProtocCommand:          flags.String("protoc_command", "protoc"),
+		ProtocFlags:            protocFlags,
+		ProtoFiles:             protos,
+		ImportDirs:             importDirs,
+		NoExpand:               noExpand,
+		Parallelism:            parallelism,
+		PrintOnly:              printOnly,
+		SquarePackageSemantics: squarePackages,
 	}
 	err = w.Init()
 	if err != nil {

--- a/wrapper/packages.go
+++ b/wrapper/packages.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -39,6 +40,9 @@ type FileInfo struct {
 	GoPackage string   // The declared go_package
 	Deps      []string // The names of files imported by this file (import-path-relative)
 
+	// Our final decision for which package this file should generate
+	// to. In the full form "path;decl" (whether decl is redundant or
+	// not) as described in github.com/golang/protobuf/issues/139
 	ComputedPackage string // Our final decision for which package this file should generate to
 }
 
@@ -172,20 +176,65 @@ func GetFileInfos(importPaths []string, protos []string, protocCommand string) (
 	return info, nil
 }
 
+// ComputeSquareGoLocations is the
+// Square-protoc-plugin-fork-compatible version of ComputeGoLocations.
+// It should go away soon, after we add full go_package declarations
+// to all our protos.
+func ComputeSquareGoLocations(infos map[string]*FileInfo) {
+	for _, info := range infos {
+		pkg := info.GoPackage
+		// The presence of a slash implies there's an import path.
+		slash := strings.LastIndex(pkg, "/")
+		if slash > 0 {
+			if strings.Contains(pkg, ";") {
+				info.ComputedPackage = pkg
+				continue
+			}
+			decl := pkg[slash+1:]
+			info.ComputedPackage = pkg + ";" + strings.Map(badToUnderscore, decl)
+			continue
+		}
+		if pkg == "" {
+			pkg = info.Package
+		}
+		if pkg == "" {
+			pkg = baseName(info.Name)
+			fmt.Fprintf(os.Stderr, "Warning: file %q has no go_package and no package.\n", info.Name)
+		}
+		parts := strings.Split(pkg, ".")
+		decl := strings.Map(badToUnderscore, parts[len(parts)-1])
+		info.ComputedPackage = "square/up/protos/" + strings.Join(parts, "/") + ";" + decl
+	}
+}
+
 // ComputeGoLocations uses the package and go_package information to
-// figure out the effective Go location and package.
+// figure out the effective Go location and package.  It sets
+// ComputedPackage to the full form "path;decl" (whether decl is
+// redundant or not) as described in
+// github.com/golang/protobuf/issues/139
 func ComputeGoLocations(infos map[string]*FileInfo) {
 	for _, info := range infos {
-		if info.GoPackage != "" {
-			info.ComputedPackage = info.GoPackage
+		dir := filepath.Dir(info.Name)
+		pkg := info.GoPackage
+		// The presence of a slash implies there's an import path.
+		slash := strings.LastIndex(pkg, "/")
+		if slash > 0 {
+			if strings.Contains(pkg, ";") {
+				info.ComputedPackage = pkg
+				continue
+			}
+			decl := pkg[slash+1:]
+			info.ComputedPackage = pkg + ";" + decl
 			continue
 		}
-		if info.Package != "" {
-			info.ComputedPackage = info.Package
-			continue
+		if pkg == "" {
+			pkg = info.Package
 		}
-		info.ComputedPackage = baseName(info.Name)
-		fmt.Fprintf(os.Stderr, "Warning: file %q has no go_package and no package.\n", info.Name)
+		if pkg == "" {
+			pkg = baseName(info.Name)
+			fmt.Fprintf(os.Stderr, "Warning: file %q has no go_package and no package.\n", info.Name)
+		}
+		info.ComputedPackage = dir + ";" + strings.Map(badToUnderscore, pkg)
 	}
 }
 
@@ -266,4 +315,14 @@ func AnnotateFullPaths(infos map[string]*FileInfo, allProtos []string, importDir
 		}
 		info.FullPath = proto
 	}
+}
+
+// badToUnderscore is the mapping function used to generate Go names from package names,
+// which can be dotted in the input .proto file.  It replaces non-identifier characters such as
+// dot or dash with underscore.
+func badToUnderscore(r rune) rune {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+		return r
+	}
+	return '_'
 }

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -39,6 +39,11 @@ type Wrapper struct {
 	NoExpand      bool     // If true, don't search for other protos in import directories.
 	PrintOnly     bool     // If true, don't generate: just print the protoc commandlines that would be called.
 
+	// If true, use Square package semantics. Note: this is a temporary
+	// hack, and will be removed as soon as Square adds full go_package
+	// declarations to all protos.
+	SquarePackageSemantics bool
+
 	allProtos   []string                // All proto files: those specified, plus those found alongside them.
 	infos       map[string]*FileInfo    // A map of filename to FileInfo struct for all proto files we care about in this run.
 	packages    map[string]*PackageInfo // A list of PackageInfo structs for packages containing files we care about.
@@ -107,7 +112,11 @@ func (w *Wrapper) Init() error {
 	}
 
 	AnnotateFullPaths(w.infos, w.allProtos, w.ImportDirs)
-	ComputeGoLocations(w.infos)
+	if w.SquarePackageSemantics {
+		ComputeSquareGoLocations(w.infos)
+	} else {
+		ComputeGoLocations(w.infos)
+	}
 
 	neededPackages := map[string]struct{}{}
 	for _, proto := range w.ProtoFiles {


### PR DESCRIPTION
- add support for full path;decl syntax, and always store computed
  packages in that format.
- move square-specific functionality (which was the default) behind a
  `square_packages` flag
