### PR TITLE
Using cross platform path list separator

### DIFF
--- a/wrapper/flags.go
+++ b/wrapper/flags.go
@@ -19,6 +19,7 @@ package wrapper
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -66,7 +67,7 @@ func ParseArgs(args []string, custom map[string]bool) (customFlags FlagValues, p
 			protocFlags = append(protocFlags, arg)
 			nextIsFlag = false
 			if nextIsImportDir {
-				importDirs = append(importDirs, strings.Split(arg, ":")...)
+				importDirs = append(importDirs, strings.Split(arg, fmt.Sprintf("%c", os.PathListSeparator))...)
 				nextIsImportDir = false
 			}
 			continue
@@ -114,7 +115,7 @@ func ParseArgs(args []string, custom map[string]bool) (customFlags FlagValues, p
 			continue
 		}
 		if arg[1] == 'I' {
-			importDirs = append(importDirs, strings.Split(arg[2:], ":")...)
+			importDirs = append(importDirs, strings.Split(arg[2:], fmt.Sprintf("%c", os.PathListSeparator))...)
 		}
 	}
 	if nextIsFlag || nextIsCustomFlag {

--- a/wrapper/flags.go
+++ b/wrapper/flags.go
@@ -67,7 +67,7 @@ func ParseArgs(args []string, custom map[string]bool) (customFlags FlagValues, p
 			protocFlags = append(protocFlags, arg)
 			nextIsFlag = false
 			if nextIsImportDir {
-				importDirs = append(importDirs, strings.Split(arg, fmt.Sprintf("%c", os.PathListSeparator))...)
+				importDirs = append(importDirs, strings.Split(arg, string(os.PathListSeparator))...)
 				nextIsImportDir = false
 			}
 			continue
@@ -115,7 +115,7 @@ func ParseArgs(args []string, custom map[string]bool) (customFlags FlagValues, p
 			continue
 		}
 		if arg[1] == 'I' {
-			importDirs = append(importDirs, strings.Split(arg[2:], fmt.Sprintf("%c", os.PathListSeparator))...)
+			importDirs = append(importDirs, strings.Split(arg[2:], string(os.PathListSeparator))...)
 		}
 	}
 	if nextIsFlag || nextIsCustomFlag {


### PR DESCRIPTION
Windows uses ";" to separate path list. Hard-coded ":" brakes one windows full paths like "c:\some\path" into two invalid peaces.