### PR TITLE
Remove square-specific package handling.

### DIFF
--- a/cmd/cyclecheck/cyclecheck.go
+++ b/cmd/cyclecheck/cyclecheck.go
@@ -31,7 +31,6 @@ var customFlags = map[string]bool{
 	"print_structure":      false,
 	"protoc_command":       true,
 	"only_specified_files": false,
-	"square_packages":      false,
 	"version":              false,
 }
 
@@ -69,18 +68,13 @@ func main() {
 	if err != nil {
 		usageAndExit("Error: %v\n", err)
 	}
-	squarePackages, err := flags.Bool("square_packages", false)
-	if err != nil {
-		usageAndExit("Error: %v\n", err)
-	}
 
 	w := &wrapper.Wrapper{
-		ProtocCommand:          flags.String("protoc_command", "protoc"),
-		ProtocFlags:            protocFlags,
-		ProtoFiles:             protos,
-		ImportDirs:             importDirs,
-		NoExpand:               noExpand,
-		SquarePackageSemantics: squarePackages,
+		ProtocCommand: flags.String("protoc_command", "protoc"),
+		ProtocFlags:   protocFlags,
+		ProtoFiles:    protos,
+		ImportDirs:    importDirs,
+		NoExpand:      noExpand,
 	}
 	err = w.Init()
 	if err != nil {

--- a/cmd/protowrap/protowrap.go
+++ b/cmd/protowrap/protowrap.go
@@ -33,7 +33,6 @@ var customFlags = map[string]bool{
 	"protoc_command":       true,
 	"only_specified_files": false,
 	"print_only":           false,
-	"square_packages":      false,
 	"version":              false,
 }
 
@@ -85,20 +84,15 @@ func main() {
 	if err != nil {
 		usageAndExit("Error: %v\n", err)
 	}
-	squarePackages, err := flags.Bool("square_packages", false)
-	if err != nil {
-		usageAndExit("Error: %v\n", err)
-	}
 
 	w := &wrapper.Wrapper{
-		ProtocCommand:          flags.String("protoc_command", "protoc"),
-		ProtocFlags:            protocFlags,
-		ProtoFiles:             protos,
-		ImportDirs:             importDirs,
-		NoExpand:               noExpand,
-		Parallelism:            parallelism,
-		PrintOnly:              printOnly,
-		SquarePackageSemantics: squarePackages,
+		ProtocCommand: flags.String("protoc_command", "protoc"),
+		ProtocFlags:   protocFlags,
+		ProtoFiles:    protos,
+		ImportDirs:    importDirs,
+		NoExpand:      noExpand,
+		Parallelism:   parallelism,
+		PrintOnly:     printOnly,
 	}
 	err = w.Init()
 	if err != nil {

--- a/wrapper/packages.go
+++ b/wrapper/packages.go
@@ -176,37 +176,6 @@ func GetFileInfos(importPaths []string, protos []string, protocCommand string) (
 	return info, nil
 }
 
-// ComputeSquareGoLocations is the
-// Square-protoc-plugin-fork-compatible version of ComputeGoLocations.
-// It should go away soon, after we add full go_package declarations
-// to all our protos.
-func ComputeSquareGoLocations(infos map[string]*FileInfo) {
-	for _, info := range infos {
-		pkg := info.GoPackage
-		// The presence of a slash implies there's an import path.
-		slash := strings.LastIndex(pkg, "/")
-		if slash > 0 {
-			if strings.Contains(pkg, ";") {
-				info.ComputedPackage = pkg
-				continue
-			}
-			decl := pkg[slash+1:]
-			info.ComputedPackage = pkg + ";" + strings.Map(badToUnderscore, decl)
-			continue
-		}
-		if pkg == "" {
-			pkg = info.Package
-		}
-		if pkg == "" {
-			pkg = baseName(info.Name)
-			fmt.Fprintf(os.Stderr, "Warning: file %q has no go_package and no package.\n", info.Name)
-		}
-		parts := strings.Split(pkg, ".")
-		decl := strings.Map(badToUnderscore, parts[len(parts)-1])
-		info.ComputedPackage = "square/up/protos/" + strings.Join(parts, "/") + ";" + decl
-	}
-}
-
 // ComputeGoLocations uses the package and go_package information to
 // figure out the effective Go location and package.  It sets
 // ComputedPackage to the full form "path;decl" (whether decl is

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -39,11 +39,6 @@ type Wrapper struct {
 	NoExpand      bool     // If true, don't search for other protos in import directories.
 	PrintOnly     bool     // If true, don't generate: just print the protoc commandlines that would be called.
 
-	// If true, use Square package semantics. Note: this is a temporary
-	// hack, and will be removed as soon as Square adds full go_package
-	// declarations to all protos.
-	SquarePackageSemantics bool
-
 	allProtos   []string                // All proto files: those specified, plus those found alongside them.
 	infos       map[string]*FileInfo    // A map of filename to FileInfo struct for all proto files we care about in this run.
 	packages    map[string]*PackageInfo // A list of PackageInfo structs for packages containing files we care about.
@@ -112,11 +107,7 @@ func (w *Wrapper) Init() error {
 	}
 
 	AnnotateFullPaths(w.infos, w.allProtos, w.ImportDirs)
-	if w.SquarePackageSemantics {
-		ComputeSquareGoLocations(w.infos)
-	} else {
-		ComputeGoLocations(w.infos)
-	}
+	ComputeGoLocations(w.infos)
 
 	neededPackages := map[string]struct{}{}
 	for _, proto := range w.ProtoFiles {


### PR DESCRIPTION
We no longer need our Square-specific package handling, so remove the
flag and code.