### PR TITLE
wrapper: try to notice the last error

### DIFF
--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -229,6 +229,10 @@ OUTER:
 	}
 	close(pkgChan)
 	wg.Wait()
+	select {
+	case err = <-errChan:
+	default:
+	}
 	return err
 }
 


### PR DESCRIPTION
After executing all commands, make one last check on the error
channel, to see whether the last command errored.