### PR TITLE
Use an arguments file when fetching proto file info

### DIFF
--- a/wrapper/packages.go
+++ b/wrapper/packages.go
@@ -139,8 +139,17 @@ func GetFileInfos(importPaths []string, protos []string, protocCommand string) (
 
 	args = append(args, "--include_imports")
 
-	for _, proto := range protos {
-		args = append(args, proto)
+	if len(protos) <= 1000 {
+		// For a small number of protos (arbitrarily picked size), pass files
+		// to protoc in the command argv
+		args = append(args, protos...)
+	} else {
+		// For a large number of protos, use a file containing the arguments
+		argfile := filepath.Join(dir, "protoc-args")
+		if err = ioutil.WriteFile(argfile, []byte(strings.Join(protos, "\n")), 0666); err != nil {
+			return nil, err
+		}
+		args = append(args, "@"+argfile)
 	}
 
 	fmt.Println("Collecting filedescriptors...")


### PR DESCRIPTION
When `protowrap` is invoked with a large number of proto files as
arguments, its call to `protoc` when building file descriptors can have
enough arguments to exceed system limits on argument size. This commit
fixes the issue by passing proto filenames in a file and using `protoc`'s
`@file` feature for reading argument from the file.