### PR TITLE
Accept argument file in protowrap args

### DIFF
--- a/cmd/protowrap/protowrap.go
+++ b/cmd/protowrap/protowrap.go
@@ -51,6 +51,9 @@ func usageAndExit(format string, args ...interface{}) {
       if true, print protoc commandlines instead of generating protos
   --version
       print version and exit
+  @file
+      read command line arguments from the named file. Each line of the file
+      will become a single argument at the position where @file is used.
 `)
 	os.Exit(1)
 }


### PR DESCRIPTION
Adds support to the protowrap command for reading additional command
line arguments from a file in the style of protoc. Finding an "@file"
argument will insert each line of the named file into the command's
arguments at that place.